### PR TITLE
Fix the KeyError exception in fetch_actual_entry

### DIFF
--- a/clippy/Clippy.py
+++ b/clippy/Clippy.py
@@ -12,11 +12,10 @@ class Clippy:
 
         return_code, stdout = self.open_main_rofi_window()
 
-        actual_entry = self.fetch_actual_entry(stdout[:-1])
+        if return_code == 0:
 
-        if return_code == 1:
-            sys.exit()
-        else:
+            actual_entry = self.fetch_actual_entry(stdout[:-1])
+
             self.save_to_clipboard(actual_entry)
 
     def open_main_rofi_window(self) -> Tuple[int, str]:

--- a/clippy/Clippy.py
+++ b/clippy/Clippy.py
@@ -12,11 +12,12 @@ class Clippy:
 
         return_code, stdout = self.open_main_rofi_window()
 
-        if return_code == 0:
+        if return_code != 0:
+            sys.exit()
 
-            actual_entry = self.fetch_actual_entry(stdout[:-1])
+        actual_entry = self.fetch_actual_entry(stdout[:-1])
 
-            self.save_to_clipboard(actual_entry)
+        self.save_to_clipboard(actual_entry)
 
     def open_main_rofi_window(self) -> Tuple[int, str]:
         rofi = run(


### PR DESCRIPTION
Hi @fdw,

this commit fixes the `KeyError` exception occurring in `fetch_actual_entry` when nothing is selected in rofi (i.e., rofi exits with return code 1).